### PR TITLE
Add missing "date" type to allowedTypes

### DIFF
--- a/src/Writer/Hive.php
+++ b/src/Writer/Hive.php
@@ -21,7 +21,7 @@ class Hive extends Writer
     private static array $allowedTypes = [
         'bigint', 'boolean', 'char', 'decimal',
         'double', 'float', 'int', 'real',
-        'smallint', 'string', 'timestamp',
+        'smallint', 'string', 'timestamp', 'date',
         'tinyint', 'varchar', 'binary',
     ];
 


### PR DESCRIPTION
Changes:
- added missing "date" type to allowedTypes (https://dzone.com/articles/hive-data-types)