### PR TITLE
chore: CI improvements and Debian Bullseye update

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ RUN aws s3 cp \
       s3://keboola-drivers/hive-odbc/clouderahiveodbc_2.8.2.1002-2_amd64.deb \
       /tmp/hive-odbc.deb
 
-FROM php:7.4-cli
+FROM php:7.4-cli-bullseye
 
 ARG COMPOSER_FLAGS="--prefer-dist --no-interaction"
 ARG DEBIAN_FRONTEND=noninteractive


### PR DESCRIPTION
## Summary
- Migrate CI from Travis to GitHub Actions
- Update base Docker image to Debian Bullseye
- Update configurations for GitHub Actions workflow
- Fix docker compose commands (remove hyphen)
- Update AWS access key and KBC developer portal credentials
- Fix expected error message for Cloudera driver

## Test plan
- [x] PHPStan passes without errors
- [x] CI pipeline runs successfully on GitHub Actions
- [x] Docker image builds correctly with Debian Bullseye

🤖 Generated with [Claude Code](https://claude.com/claude-code)